### PR TITLE
removed dead assignment to argc variable

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -730,7 +730,6 @@ int cms_main(int argc, char **argv)
     }
 
     /* Remaining args are files to process. */
-    argc = opt_num_rest();
     argv = opt_rest();
 
     if ((rr_allorfirst != -1 || rr_from != NULL) && rr_to == NULL) {


### PR DESCRIPTION
Fixes #25825

In the file at apps/cms.c on line 731 there was a dead assignment line `argc = opt_num_rest();`, which I went ahead and removed as requested in the issue above.

CLA: trivial

NOTE: I did see someone had already attempted to make a change, but their pull request has been stalled for about a month so I thought I would go ahead and try to push this fix through all the way.